### PR TITLE
fix: specify ActionUpdateThread for tool window actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+gradlew    text eol=lf
+*.sh       text eol=lf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf

--- a/src/main/kotlin/com/aifhandoff/plugin/AifToolWindowFactory.kt
+++ b/src/main/kotlin/com/aifhandoff/plugin/AifToolWindowFactory.kt
@@ -3,6 +3,7 @@ package com.aifhandoff.plugin
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -57,8 +58,8 @@ private class AifToolWindowPanel(private val project: Project) : JPanel(BorderLa
     private lateinit var settingsAction: AnAction
     private lateinit var openInBrowserAction: AnAction
     private lateinit var viewPlanAction: AnAction
-    private var viewPlanEnabled = false
-    private var currentTaskPlanPath: String? = null
+    @Volatile private var viewPlanEnabled = false
+    @Volatile private var currentTaskPlanPath: String? = null
     private var startEnabled = true
     private var stopEnabled = false
     private var refreshEnabled = false
@@ -100,33 +101,40 @@ private class AifToolWindowPanel(private val project: Project) : JPanel(BorderLa
     private fun buildUI() {
         // --- Toolbar (IDE-style action toolbar) ---
         startAction = object : AnAction("Start", "Start AIF Handoff server", AllIcons.Actions.Execute) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) = onStart()
             override fun update(e: AnActionEvent) { e.presentation.isEnabled = startEnabled }
         }
         stopAction = object : AnAction("Stop", "Stop AIF Handoff server", AllIcons.Actions.Suspend) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) = onStop()
             override fun update(e: AnActionEvent) { e.presentation.isEnabled = stopEnabled }
         }
         refreshAction = object : AnAction("Refresh", "Refresh browser", AllIcons.Actions.Refresh) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) {
                 browser?.cefBrowser?.reloadIgnoreCache()
             }
             override fun update(e: AnActionEvent) { e.presentation.isEnabled = refreshEnabled }
         }
         updateAction = object : AnAction("Update", "Update from upstream repository", AllIcons.Actions.CheckOut) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) = onUpdate()
             override fun update(e: AnActionEvent) { e.presentation.isEnabled = updateEnabled }
         }
         settingsAction = object : AnAction("Settings", "Edit environment variables", AllIcons.General.Settings) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) = onSettings()
         }
 
         viewPlanAction = object : AnAction("View Plan", "Open task plan in editor", AllIcons.Actions.PreviewDetails) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) = onViewPlan()
             override fun update(e: AnActionEvent) { e.presentation.isEnabled = viewPlanEnabled }
         }
 
         openInBrowserAction = object : AnAction("Open in Browser", "Open board in external browser", AllIcons.General.Web) {
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
             override fun actionPerformed(e: AnActionEvent) {
                 BrowserUtil.browse(getUrl())
             }
@@ -134,6 +142,7 @@ private class AifToolWindowPanel(private val project: Project) : JPanel(BorderLa
         }
 
         val logAction = object : AnAction("Toggle Log", "Show/hide API log", AllIcons.Debugger.Console) {
+            override fun getActionUpdateThread() = ActionUpdateThread.EDT
             override fun actionPerformed(e: AnActionEvent) {
                 logPanel.isVisible = !logPanel.isVisible
                 this@AifToolWindowPanel.revalidate()


### PR DESCRIPTION
Opening the AIF Handoff tool window throws `PluginException: ActionUpdateThread.OLD_EDT is deprecated and going to be removed soon` on recent IntelliJ Platform versions, so the panel never appears.

Root cause: none of the `AnAction` subclasses created in `AifToolWindowPanel.buildUI()` override `getActionUpdateThread()`, so the platform falls back to the now-forbidden `OLD_EDT`.

## Steps to Reproduce

1. Install the plugin into a recent IntelliJ-based IDE (2024.2+ / PhpStorm 2024.2+).
2. Open any project.
3. Click the **AIF Handoff** tool window in the sidebar.

## Expected Behavior

The tool window opens and the toolbar (Start / Stop / Refresh / Update / Settings / View Plan / Open in Browser / Toggle Log) is rendered.

## Actual Behavior

The tool window fails to initialize. The IDE log shows:

```
PluginException: ActionUpdateThread.OLD_EDT is deprecated and going to be removed soon
```

## Environment

- OS: Windows 11 (host) + WSL2 Ubuntu 22.04, also reproduced on Linux
- IDE: PhpStorm 2024.2+
- JDK: bundled
- Plugin commit: prior to this fix

## Additional Context

Fix in this PR:

- Override `getActionUpdateThread()` on all 8 toolbar actions. `BGT` everywhere except `logAction`, which mutates Swing state directly and stays on `EDT`.
- Mark `viewPlanEnabled` / `currentTaskPlanPath` as `@Volatile`. They are written from `invokeLater` (EDT) and now read from `update()` running on BGT, so the prior happens-before guarantee no longer holds.
- Add `.gitattributes` enforcing LF for `gradlew` and `*.sh`. This only affects contributors who build from source: on a Windows checkout git auto-converts `gradlew` to CRLF, and a subsequent build on Linux/macOS (or WSL) fails with `bad interpreter: /bin/sh^M`. End users who download a prebuilt plugin from Releases are unaffected.
