### PR TITLE
fix: skip repo hooks during plugin-internal git sync on Windows

### DIFF
--- a/src/main/kotlin/com/aifhandoff/plugin/AifDevServerService.kt
+++ b/src/main/kotlin/com/aifhandoff/plugin/AifDevServerService.kt
@@ -182,8 +182,8 @@ class AifDevServerService(private val project: Project) : Disposable {
         setState(State.CLONING)
         if (INSTALL_DIR.resolve(".git").exists()) {
             notify("Pulling latest changes...", NotificationType.INFORMATION)
-            runCmd(findGit(), "checkout", ".", workDir = INSTALL_DIR, label = "git checkout .")
-            runCmd(findGit(), "pull", "--ff-only", workDir = INSTALL_DIR, label = "git pull")
+            runCmd(findGit(), "-c", "core.hooksPath=", "checkout", ".", workDir = INSTALL_DIR, label = "git checkout .")
+            runCmd(findGit(), "-c", "core.hooksPath=", "pull", "--ff-only", workDir = INSTALL_DIR, label = "git pull")
         } else {
             notify("Cloning repository...", NotificationType.INFORMATION)
             runCmd(findGit(), "clone", REPO_URL, INSTALL_DIR.absolutePath, label = "git clone")


### PR DESCRIPTION
The update routine runs `git checkout .` and `git pull` in ~/.aif-handoff via runCmd, which rebuilds PATH with git.exe/node/npm locations but does not include Git for Windows' `usr/bin`. When the target repo uses husky (a POSIX shell hook), the post-checkout hook fails with:

    .husky/_/post-checkout: line 2: dirname: command not found

Plugin-internal checkouts don't need repo hooks to run — pass `-c core.hooksPath=` to disable them for these specific invocations. This is a standard git flag, behaves identically across platforms, and doesn't touch repo config.